### PR TITLE
redis.cache.flushallonstop configuration option for skipping flushAll pr...

### DIFF
--- a/src/play/modules/redis/RedisCacheImpl.java
+++ b/src/play/modules/redis/RedisCacheImpl.java
@@ -229,7 +229,9 @@ public class RedisCacheImpl implements CacheImpl {
 
 	@Override
 	public void stop() {
-		getCacheConnection().flushAll();
+		if (Play.configuration.getProperty("redis.cache.flushallonstop", "true").equals("true")) {
+			getCacheConnection().flushAll();
+		}
 		connectionPool.destroy();
 	}
 


### PR DESCRIPTION
This is a maintenance request for redis cache plugin.

I want to modify this plugin to make it possible to choose whether flush all data or not when the plugin is stopping.
So I added "redis.cache.flushallonstop=false" configuration to skip flushAll on stop.

I'd appreciate it if you could accept this configuration and update this plugin.
(Some my system uses your plugin and this configuration helps me)

Thank you.
